### PR TITLE
fix: add back CJS compat code from Rollup

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,5 +3,6 @@ export default {
   output: {
     file: 'lib/index.js',
     format: 'cjs',
+    interop: 'compat',
   },
 };


### PR DESCRIPTION
Fixes: https://github.com/mljs/regression-exponential/issues/18
