### PR TITLE
fix: add missing A and B in class type

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Exponential Regression.
 
 ## Usage
 
-This calculates parameters A and B for the equation `y = A * e^(B * x)`.
+This calculates parameters A and B for the equation `y = B * e^(A * x)`.
 
 ```js
 import ExponentialRegression from 'ml-regression-exponential';

--- a/regression-exponential.d.ts
+++ b/regression-exponential.d.ts
@@ -6,6 +6,9 @@ export interface ExponentialRegressionModel {
   B: number;
 }
 export declare class ExponentialRegression extends BaseRegression {
+  A: number;
+  B: number;
+
   constructor(x: number[], y: number[]);
 
   static load(model: ExponentialRegressionModel): ExponentialRegression;

--- a/regression-exponential.d.ts
+++ b/regression-exponential.d.ts
@@ -7,12 +7,12 @@ export interface ExponentialRegressionModel {
 }
 export declare class ExponentialRegression extends BaseRegression {
   /**
-   * The coefficient `A` in the equation `y = A * e^(B * x)`.
+   * The exponent coefficient `A` in the equation `y = B * e^(A * x)`.
    */
   A: number;
 
   /**
-   * The exponent coefficient `B` in the equation `y = A * e^(B * x)`.
+   * The coefficient `B` in the equation `y = B * e^(A * x)`.
    */
   B: number;
 

--- a/regression-exponential.d.ts
+++ b/regression-exponential.d.ts
@@ -6,7 +6,14 @@ export interface ExponentialRegressionModel {
   B: number;
 }
 export declare class ExponentialRegression extends BaseRegression {
+  /**
+   * The coefficient `A` in the equation `y = A * e^(B * x)`.
+   */
   A: number;
+
+  /**
+   * The exponent coefficient `B` in the equation `y = A * e^(B * x)`.
+   */
   B: number;
 
   constructor(x: number[], y: number[]);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/162d0af5-19d5-4c6d-a477-30ffa0f2927d)

Property `A` and `B` does not exist on type `ExponentialRegression`, this PR fixes this issue.